### PR TITLE
Add selectors for "Evolved Issues UI"

### DIFF
--- a/style.css
+++ b/style.css
@@ -45,6 +45,16 @@ body:not(.is-github-wide-disabled) .Layout-main div[style="--sticky-pane-height:
   max-width: none;
 }
 
+/* Issue list */
+body:not(.is-github-wide-disabled) main div[data-target="react-app.reactRoot"] div[style="--sticky-pane-height: 100vh;"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-']:nth-child(2) > div[class^='Box-sc-'] {
+  max-width: none;
+}
+
+/* Issue detail */
+body:not(.is-github-wide-disabled) main div[data-target="react-app.reactRoot"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] {
+  max-width: none;
+}
+
 body:not(.is-github-wide-disabled) .pr-toolbar {
   margin-left: -16px !important;
   margin-right: -16px !important;

--- a/style.css
+++ b/style.css
@@ -55,6 +55,11 @@ body:not(.is-github-wide-disabled) main div[data-target="react-app.reactRoot"] >
   max-width: none;
 }
 
+/* Issue scrolled header */
+body:not(.is-github-wide-disabled) main div[data-target="react-app.reactRoot"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div.js-notification-shelf-offset-top > div[class^='Box-sc-'] {
+  max-width: none;
+}
+
 body:not(.is-github-wide-disabled) .pr-toolbar {
   margin-left: -16px !important;
   margin-right: -16px !important;


### PR DESCRIPTION
Fixes https://github.com/fabiocchetti/wide-github/issues/24

This PR adds selectors for the new GitHub issue UI so they also expand to fill the screen like all other GitHub pages.

I tried my best to use similar selectors/strategies for these new views. The issue list and the issue detail page appear to use different layouts, so I had to add one for each page.

Let me know if you have any other thoughts or feedback!
