### PR TITLE
fix: repository code page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_STORE
 .idea/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_STORE
 .idea/
 dist/
+wide-github-*.zip

--- a/src/style.css
+++ b/src/style.css
@@ -3,7 +3,6 @@ html[data-wide-github-init] body {
   opacity: 0 !important;
   transition: none !important;
 }
-
 html.is-wide-github-enabled body,
 html:not(.is-wide-github-enabled)[data-wide-github-init] body {
   opacity: 1 !important;
@@ -46,7 +45,7 @@ html.is-wide-github-enabled #js-repo-pjax-container .repository-content .discuss
 }
 
 html.is-wide-github-enabled #js-repo-pjax-container div[style="--sticky-pane-height:100vh"],
-html.is-wide-github-enabled #js-repo-pjax-container div[style="--sticky-pane-height: 100vh;"]>div[class^='Box-sc-']:first-child {
+html.is-wide-github-enabled #js-repo-pjax-container div[style="--sticky-pane-height: 100vh;"] > div[class^='Box-sc-']:first-child {
   max-width: none;
 }
 
@@ -54,13 +53,13 @@ html.is-wide-github-enabled .Layout-main div[data-selector="repos-split-pane-con
   max-width: none !important;
 }
 
-html.is-wide-github-enabled .Layout-main div[style="--sticky-pane-height: 100vh;"]>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']:nth-child(2),
-html.is-wide-github-enabled .Layout-main div[style="--sticky-pane-height:100vh"]>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']:nth-child(2) {
+html.is-wide-github-enabled .Layout-main div[style="--sticky-pane-height: 100vh;"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-']:nth-child(2),
+html.is-wide-github-enabled .Layout-main div[style="--sticky-pane-height:100vh"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-']:nth-child(2) {
   max-width: none;
 }
 
 /* Issue list */
-html.is-wide-github-enabled main div[data-target="react-app.reactRoot"] div[style="--sticky-pane-height: 100vh;"]>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']:nth-child(2)>div[class^='Box-sc-'] {
+html.is-wide-github-enabled main div[data-target="react-app.reactRoot"] div[style="--sticky-pane-height: 100vh;"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-']:nth-child(2) > div[class^='Box-sc-'] {
   max-width: none;
 }
 
@@ -69,16 +68,16 @@ html.is-wide-github-enabled main div[class^='ThreePanesLayout'] {
 }
 
 /* Issues list page */
-html.is-wide-github-enabled .application-main div[data-target="react-app.reactRoot"] div[class^="prc-PageLayout-Content-"]>div[class^="Box-sc-"] {
+html.is-wide-github-enabled .application-main div[data-target="react-app.reactRoot"] div[class^="prc-PageLayout-Content-"] > div[class^="Box-sc-"] {
   max-width: none !important;
 }
 
-html.is-wide-github-enabled main div[class*="prc-PageLayout-Content--"]>div[class^="Box-sc-"] {
+html.is-wide-github-enabled main div[class*="prc-PageLayout-Content--"] > div[class^="Box-sc-"] {
   max-width: none;
 }
 
 /* Issue detail */
-html.is-wide-github-enabled main div[data-target="react-app.reactRoot"]>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-'] {
+html.is-wide-github-enabled main div[data-target="react-app.reactRoot"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] {
   max-width: none;
 }
 
@@ -87,7 +86,7 @@ html.is-wide-github-enabled main div[class^='IssueViewer'] div[class^='ContentWr
 }
 
 /* Issue page */
-html.is-wide-github-enabled .application-main div[data-target="react-app.reactRoot"]>div[class^="Box-sc-"]>div[class^="Box-sc-"]>div[class^="Box-sc-"]>div[class^="Box-sc-"] {
+html.is-wide-github-enabled .application-main div[data-target="react-app.reactRoot"] > div[class^="Box-sc-"] > div[class^="Box-sc-"] > div[class^="Box-sc-"] > div[class^="Box-sc-"] {
   max-width: none !important;
 }
 
@@ -97,7 +96,7 @@ html.is-wide-github-enabled .application-main div[data-target="react-app.reactRo
 }
 
 /* Issue scrolled header */
-html.is-wide-github-enabled main div[data-target="react-app.reactRoot"]>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']>div.js-notification-shelf-offset-top>div[class^='Box-sc-'] {
+html.is-wide-github-enabled main div[data-target="react-app.reactRoot"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div.js-notification-shelf-offset-top > div[class^='Box-sc-'] {
   max-width: none;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -3,6 +3,7 @@ html[data-wide-github-init] body {
   opacity: 0 !important;
   transition: none !important;
 }
+
 html.is-wide-github-enabled body,
 html:not(.is-wide-github-enabled)[data-wide-github-init] body {
   opacity: 1 !important;
@@ -45,7 +46,7 @@ html.is-wide-github-enabled #js-repo-pjax-container .repository-content .discuss
 }
 
 html.is-wide-github-enabled #js-repo-pjax-container div[style="--sticky-pane-height:100vh"],
-html.is-wide-github-enabled #js-repo-pjax-container div[style="--sticky-pane-height: 100vh;"] > div[class^='Box-sc-']:first-child {
+html.is-wide-github-enabled #js-repo-pjax-container div[style="--sticky-pane-height: 100vh;"]>div[class^='Box-sc-']:first-child {
   max-width: none;
 }
 
@@ -53,13 +54,13 @@ html.is-wide-github-enabled .Layout-main div[data-selector="repos-split-pane-con
   max-width: none !important;
 }
 
-html.is-wide-github-enabled .Layout-main div[style="--sticky-pane-height: 100vh;"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-']:nth-child(2),
-html.is-wide-github-enabled .Layout-main div[style="--sticky-pane-height:100vh"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-']:nth-child(2) {
+html.is-wide-github-enabled .Layout-main div[style="--sticky-pane-height: 100vh;"]>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']:nth-child(2),
+html.is-wide-github-enabled .Layout-main div[style="--sticky-pane-height:100vh"]>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']:nth-child(2) {
   max-width: none;
 }
 
 /* Issue list */
-html.is-wide-github-enabled main div[data-target="react-app.reactRoot"] div[style="--sticky-pane-height: 100vh;"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-']:nth-child(2) > div[class^='Box-sc-'] {
+html.is-wide-github-enabled main div[data-target="react-app.reactRoot"] div[style="--sticky-pane-height: 100vh;"]>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']:nth-child(2)>div[class^='Box-sc-'] {
   max-width: none;
 }
 
@@ -68,16 +69,16 @@ html.is-wide-github-enabled main div[class^='ThreePanesLayout'] {
 }
 
 /* Issues list page */
-html.is-wide-github-enabled .application-main div[data-target="react-app.reactRoot"] div[class^="prc-PageLayout-Content-"] > div[class^="Box-sc-"] {
+html.is-wide-github-enabled .application-main div[data-target="react-app.reactRoot"] div[class^="prc-PageLayout-Content-"]>div[class^="Box-sc-"] {
   max-width: none !important;
 }
 
-html.is-wide-github-enabled main div[class*="prc-PageLayout-Content--"] > div[class^="Box-sc-"] {
+html.is-wide-github-enabled main div[class*="prc-PageLayout-Content--"]>div[class^="Box-sc-"] {
   max-width: none;
 }
 
 /* Issue detail */
-html.is-wide-github-enabled main div[data-target="react-app.reactRoot"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] {
+html.is-wide-github-enabled main div[data-target="react-app.reactRoot"]>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-'] {
   max-width: none;
 }
 
@@ -86,7 +87,7 @@ html.is-wide-github-enabled main div[class^='IssueViewer'] div[class^='ContentWr
 }
 
 /* Issue page */
-html.is-wide-github-enabled .application-main div[data-target="react-app.reactRoot"] > div[class^="Box-sc-"] > div[class^="Box-sc-"] > div[class^="Box-sc-"] > div[class^="Box-sc-"] {
+html.is-wide-github-enabled .application-main div[data-target="react-app.reactRoot"]>div[class^="Box-sc-"]>div[class^="Box-sc-"]>div[class^="Box-sc-"]>div[class^="Box-sc-"] {
   max-width: none !important;
 }
 
@@ -96,7 +97,7 @@ html.is-wide-github-enabled .application-main div[data-target="react-app.reactRo
 }
 
 /* Issue scrolled header */
-html.is-wide-github-enabled main div[data-target="react-app.reactRoot"] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div[class^='Box-sc-'] > div.js-notification-shelf-offset-top > div[class^='Box-sc-'] {
+html.is-wide-github-enabled main div[data-target="react-app.reactRoot"]>div[class^='Box-sc-']>div[class^='Box-sc-']>div[class^='Box-sc-']>div.js-notification-shelf-offset-top>div[class^='Box-sc-'] {
   max-width: none;
 }
 
@@ -129,5 +130,10 @@ html.is-wide-github-enabled [class^="prc-PageLayout-Content-"]:has(> .pull-discu
 
 /* Repository settings */
 html.is-wide-github-enabled .container-md {
+  max-width: 100% !important;
+}
+
+/* Repository code page */
+html.is-wide-github-enabled .prc-PageLayout-Content-xWL-A:where([data-width="large"]) {
   max-width: 100% !important;
 }


### PR DESCRIPTION
This pull request:
- fixes the "Code" page's width in repositories
- adds the `dist/` directory and `package.sh` output files (wide-github-firefox.zip & wide-github-chrome.zip) to `.gitignore`

Note: The code page breaks for me only when I'm logged in. I think that GitHub is testing some sort of a new feature.

| Before | After |
|--------|--------|
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9310c96c-d50c-4849-a680-2a236d347a38" /> | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a4d0bbed-62b9-42c5-a0cc-ca40bca4b45b" /> | 
